### PR TITLE
Streaming queries

### DIFF
--- a/cmd/oklog/main.go
+++ b/cmd/oklog/main.go
@@ -30,6 +30,7 @@ func usage() {
 	fmt.Fprintf(os.Stderr, "  store        Storage node\n")
 	fmt.Fprintf(os.Stderr, "  ingeststore  Combination ingest+store node, for small installations\n")
 	fmt.Fprintf(os.Stderr, "  query        Querying commandline tool\n")
+	fmt.Fprintf(os.Stderr, "  stream       Streaming commandline tool\n")
 	fmt.Fprintf(os.Stderr, "  testsvc      Test service, emits log lines at a fixed rate\n")
 	fmt.Fprintf(os.Stderr, "\n")
 	fmt.Fprintf(os.Stderr, "VERSION\n")
@@ -55,6 +56,8 @@ func main() {
 		run = runIngestStore
 	case "query":
 		run = runQuery
+	case "stream":
+		run = runStream
 	case "testsvc":
 		run = runTestService
 	default:

--- a/cmd/oklog/store.go
+++ b/cmd/oklog/store.go
@@ -266,7 +266,7 @@ func runStore(args []string) error {
 	{
 		g.Add(func() error {
 			mux := http.NewServeMux()
-			mux.Handle("/store/", http.StripPrefix("/store", store.NewAPI(
+			api := store.NewAPI(
 				peer,
 				storeLog,
 				httpClient,
@@ -274,7 +274,13 @@ func runStore(args []string) error {
 				replicatedBytes.WithLabelValues("ingress"),
 				apiDuration,
 				logger,
-			)))
+			)
+			defer func() {
+				if err := api.Close(); err != nil {
+					level.Warn(logger).Log("err", err)
+				}
+			}()
+			mux.Handle("/store/", http.StripPrefix("/store", api))
 			registerMetrics(mux)
 			registerProfile(mux)
 			return http.Serve(apiListener, mux)

--- a/cmd/oklog/stream.go
+++ b/cmd/oklog/stream.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/oklog/oklog/pkg/group"
+	"github.com/oklog/oklog/pkg/store"
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+)
+
+func runStream(args []string) error {
+	flagset := flag.NewFlagSet("stream", flag.ExitOnError)
+	var (
+		storeAddr = flagset.String("store", "localhost:7650", "address of store instance to query")
+		q         = flagset.String("q", "", "query expression")
+		regex     = flagset.Bool("regex", false, "parse -q as regular expression")
+		window    = flagset.Duration("window", 3*time.Second, "deduplication window")
+		withulid  = flagset.Bool("ulid", false, "include ULID prefix with each record")
+	)
+	flagset.Usage = usageFor(flagset, "oklog stream [flags]")
+	if err := flagset.Parse(args); err != nil {
+		return err
+	}
+
+	_, hostport, _, _, err := parseAddr(*storeAddr, defaultAPIPort)
+	if err != nil {
+		return errors.Wrap(err, "couldn't parse -store")
+	}
+
+	var asRegex string
+	if *regex {
+		asRegex = "&regex=true"
+	}
+
+	var offset int = ulid.EncodedSize + 1
+	if *withulid {
+		offset = 0
+	}
+
+	req, err := http.NewRequest("GET", fmt.Sprintf(
+		"http://%s/store%s?q=%s&window=%s%s",
+		hostport,
+		store.APIPathUserStream,
+		url.QueryEscape(*q),
+		url.QueryEscape(window.String()),
+		asRegex,
+	), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		req.URL.RawQuery = "" // for pretty print
+		return errors.Errorf("%s %s: %s", req.Method, req.URL.String(), resp.Status)
+	}
+	defer resp.Body.Close()
+
+	var g group.Group
+	{
+		g.Add(func() error {
+			scanner := bufio.NewScanner(resp.Body)
+			for scanner.Scan() {
+				fmt.Fprintf(os.Stdout, "%s\n", scanner.Bytes()[offset:])
+			}
+			return scanner.Err()
+		}, func(error) {
+			resp.Body.Close()
+		})
+	}
+	{
+		cancel := make(chan struct{})
+		g.Add(func() error {
+			return interrupt(cancel)
+		}, func(error) {
+			close(cancel)
+		})
+	}
+	return g.Run()
+}

--- a/pkg/store/api.go
+++ b/pkg/store/api.go
@@ -340,8 +340,26 @@ func (a *API) handleUserStream(w http.ResponseWriter, r *http.Request) {
 		time.NewTicker,
 	)
 
+	//c := make(chan int)
+	//go func() {
+	//	var (
+	//		slice = make([]bool, 10000)
+	//		next  = 1
+	//	)
+	//	for i := range c {
+	//		slice[i] = true
+	//		fmt.Fprintf(os.Stderr, "### check·Write %d (next=%d)\n", i, next)
+	//		for slice[next] == true {
+	//			fmt.Fprintf(os.Stderr, "### check·Verify %d OK\n", next)
+	//			next++
+	//		}
+	//	}
+	//}()
+
 	// Thus, we range over the deduplicated chan.
 	for record := range deduplicated {
+		//i, _ := strconv.Atoi(strings.Fields(string(record))[3])
+		//c <- i
 		w.Write(record)
 		w.Write([]byte{'\n'})
 		flusher.Flush()
@@ -424,7 +442,9 @@ func teeRecords(src io.Reader, dst ...io.Writer) (lo, hi ulid.ULID, n int, err e
 	)
 	for s.Scan() {
 		// ULID and record-count accounting.
-		id.UnmarshalText(s.Bytes()[:ulid.EncodedSize])
+		if err := id.UnmarshalText(s.Bytes()[:ulid.EncodedSize]); err != nil {
+			return lo, hi, n, err
+		}
 		if first {
 			lo, first = id, false
 		}

--- a/pkg/store/api.go
+++ b/pkg/store/api.go
@@ -340,26 +340,8 @@ func (a *API) handleUserStream(w http.ResponseWriter, r *http.Request) {
 		time.NewTicker,
 	)
 
-	//c := make(chan int)
-	//go func() {
-	//	var (
-	//		slice = make([]bool, 10000)
-	//		next  = 1
-	//	)
-	//	for i := range c {
-	//		slice[i] = true
-	//		fmt.Fprintf(os.Stderr, "### check·Write %d (next=%d)\n", i, next)
-	//		for slice[next] == true {
-	//			fmt.Fprintf(os.Stderr, "### check·Verify %d OK\n", next)
-	//			next++
-	//		}
-	//	}
-	//}()
-
 	// Thus, we range over the deduplicated chan.
 	for record := range deduplicated {
-		//i, _ := strconv.Atoi(strings.Fields(string(record))[3])
-		//c <- i
 		w.Write(record)
 		w.Write([]byte{'\n'})
 		flusher.Flush()

--- a/pkg/store/api.go
+++ b/pkg/store/api.go
@@ -307,7 +307,7 @@ func (a *API) handleUserStream(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Use the special stream client, which doesn't time out.
-	readerFactory := stream.HTTPReaderFactory(a.streamClient, func(addr string) string {
+	readCloserFactory := stream.HTTPReadCloserFactory(a.streamClient, func(addr string) string {
 		// Copy original URL, to save all the query params, etc.
 		u, err := url.Parse(r.URL.String())
 		if err != nil {
@@ -328,7 +328,7 @@ func (a *API) handleUserStream(w http.ResponseWriter, r *http.Request) {
 	raw := stream.Execute(
 		r.Context(),
 		peerFactory,
-		readerFactory,
+		readCloserFactory,
 		time.Sleep,
 		time.NewTicker,
 	)

--- a/pkg/store/log.go
+++ b/pkg/store/log.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"context"
 	"errors"
 	"io"
 	"time"
@@ -15,12 +14,7 @@ type Log interface {
 	Create() (WriteSegment, error)
 
 	// Query written and closed segments.
-	// TODO(pb): convert parameters to QueryParams
 	Query(qp QueryParams, statsOnly bool) (QueryResult, error)
-
-	// Register a streaming query, giving results on the result chan.
-	// Canceling the context closes the returned channel.
-	Stream(context.Context, QueryParams) <-chan []byte
 
 	// Overlapping returns segments that have a high degree of time overlap and
 	// can be compacted.

--- a/pkg/store/query.go
+++ b/pkg/store/query.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -43,6 +44,13 @@ func (qp *QueryParams) DecodeFrom(u *url.URL) error {
 	qp.To = to
 	qp.Q = u.Query().Get("q")
 	_, qp.Regex = u.Query()["regex"]
+
+	if qp.Regex {
+		if _, err := regexp.Compile(qp.Q); err != nil {
+			return errors.Wrap(err, "compiling regex")
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/store/query.go
+++ b/pkg/store/query.go
@@ -369,7 +369,7 @@ func newConcurrentFilteringReadCloser(src io.ReadCloser, pass recordFilter, bufs
 				w.CloseWithError(err)
 				return
 			}
-			if !pass(line[ulid.EncodedSize+1:]) {
+			if !pass(line) {
 				continue
 			}
 			switch n, err := w.Write(line); {

--- a/pkg/store/query_registry.go
+++ b/pkg/store/query_registry.go
@@ -1,0 +1,134 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// queryRegistry holds active streaming queries.
+type queryRegistry struct {
+	mtx     sync.RWMutex
+	reg     map[chan<- []byte]queryContext
+	closing bool
+}
+
+type queryContext struct {
+	pass   recordFilter
+	done   <-chan struct{}
+	cancel func()
+}
+
+func newQueryRegistry() *queryRegistry {
+	return &queryRegistry{
+		reg: map[chan<- []byte]queryContext{},
+	}
+}
+
+// Register a new query. If successful, range over the returned chan for
+// incoming records. If not successful, the returned chan will be nil.
+func (qr *queryRegistry) Register(ctx context.Context, pass recordFilter) <-chan []byte {
+	qr.mtx.Lock()
+	defer qr.mtx.Unlock()
+
+	// Don't accept new registrations if we're shutting down.
+	if qr.closing {
+		return nil
+	}
+
+	// Queries are typically deregistered when the parent context is canceled.
+	// So we build our lifecycle management purely on context cancelation.
+	// But what happens when we want to stop the queryRegistry itself?
+	// We need a side-channel way to cancel each registered query.
+	subctx, cancel := context.WithCancel(ctx)
+
+	// Create the record chan, and register it.
+	// TODO(pb): validate the buffer size
+	c := make(chan []byte, 1024)
+	qr.reg[c] = queryContext{pass, subctx.Done(), cancel}
+
+	// Canceling the context should deregister the query and close the chan.
+	// Spawn a cleanup goroutine to wait for the cancelation and do just that.
+	// The cancel may come while we're doing a batch of Match sends.
+	// That's fine; we detect it there, too, and stop sending records.
+	// But we leave all cleanup duties for this little goroutine here.
+	// Note: this is the ONLY place where we can close the records chan!
+	go func() {
+		<-subctx.Done()       // wait for cancel
+		qr.mtx.Lock()         // take the write lock
+		defer qr.mtx.Unlock() //
+		delete(qr.reg, c)     // deregister the query
+		close(c)              // signal we're done
+	}()
+
+	// The user should range over this chan for matching records.
+	return c
+}
+
+func (qr *queryRegistry) Close() error {
+	qr.mtx.Lock()
+	defer qr.mtx.Unlock()
+
+	// We're shutting down. No more registrations.
+	qr.closing = true
+
+	// Channels must have a single "owner" i.e. closer.
+	// We've already given that responsibility to the cleanup goroutine.
+	// So we need to trigger it, via our side-channel cancelation mechanism.
+	for _, qc := range qr.reg {
+		qc.cancel()
+	}
+
+	// Block until everything is done.
+	// This is a little hacky. That's fine. I think.
+	timeout := time.After(1 * time.Second)
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		qr.mtx.Unlock()
+		select {
+		case <-ticker.C:
+			qr.mtx.Lock()
+			if len(qr.reg) <= 0 {
+				return nil // empty, we're done
+			}
+		case <-timeout:
+			qr.mtx.Lock()
+			return errors.New("timeout waiting for query registry shutdown")
+		}
+	}
+}
+
+// Match a segment of records against the set of registered queries.
+// The function may block if channel receivers are slow.
+// Perhaps best to run in a goroutine?
+func (qr *queryRegistry) Match(segment [][]byte) {
+	qr.mtx.RLock()
+	defer qr.mtx.RUnlock()
+
+	// No need to do this work if we don't have any registered queries.
+	if len(qr.reg) <= 0 {
+		return
+	}
+
+	// Match each record in the segment against the registered queries.
+	// Send any matches immediately.
+	for _, record := range segment {
+	inner:
+		for c, qc := range qr.reg {
+			if qc.pass(record) {
+				select {
+				case c <- record:
+					// It's a good send, Bront.
+				case <-qc.done:
+					// We're canceled! The cancelation was also detected by the
+					// cleanup goroutine spawned by Register. That goroutine is in
+					// charge of deregistering the query and closing the chan. For
+					// our part, we should just stop sending records to this chan.
+					break inner
+				}
+			}
+		}
+	}
+}

--- a/pkg/store/query_registry.go
+++ b/pkg/store/query_registry.go
@@ -131,14 +131,15 @@ func (qr *queryRegistry) Match(segment []byte) {
 		for c, qc := range qr.reg {
 			if qc.pass(s.Bytes()) {
 				select {
-				case c <- s.Bytes():
-					// It's a good send, Bront.
+				case c <- []byte(s.Text()):
+					// We use s.Text to copy the record out of the Scanner.
 
 				case <-qc.done:
 					// We're canceled! The cancelation was also detected by the
-					// cleanup goroutine spawned by Register. That goroutine is in
-					// charge of deregistering the query and closing the chan. For
-					// our part, we should just stop sending records to this chan.
+					// cleanup goroutine spawned by Register. That goroutine is
+					// in charge of deregistering the query and closing the
+					// chan. For our part, we should just stop sending records
+					// to this chan.
 					continue
 				}
 			}

--- a/pkg/store/query_registry_test.go
+++ b/pkg/store/query_registry_test.go
@@ -1,0 +1,156 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid"
+)
+
+func TestQueryRegistry(t *testing.T) {
+	// Set up an empty query registry.
+	qr := newQueryRegistry()
+	defer qr.Close()
+
+	// Register a query for 'foo' records.
+	fooctx, foocancel := context.WithCancel(context.Background())
+	fooc := qr.Register(fooctx, recordFilterPlain([]byte("foo")))
+
+	// Register a query for 'bar' records.
+	barctx, barcancel := context.WithCancel(context.Background())
+	barc := qr.Register(barctx, recordFilterPlain([]byte("bar")))
+
+	// A helper function to generate segments.
+	nopulid := ulid.MustNew(0, nil).String()
+	makeSegment := func(records ...string) []byte {
+		var buf bytes.Buffer
+		for _, record := range records {
+			fmt.Fprintf(&buf, "%s %s\n", nopulid, record)
+		}
+		return buf.Bytes()
+	}
+
+	// Push a segment through that should match foo.
+	go qr.Match(makeSegment("no match", "abc foo def", "no match again"))
+	select {
+	case foo := <-fooc:
+		if want, have := nopulid+" abc foo def", string(foo); want != have {
+			t.Errorf("want %q, have %q", want, have)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout on first Match")
+	}
+
+	// Cancel the foo query, make sure the chan gets closed.
+	foocancel()
+	select {
+	case foo, ok := <-fooc:
+		if ok {
+			t.Errorf("got unexpected record on foo chan: %s", foo)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout on foocancel")
+	}
+
+	// Push a segment through that matches foo and bar.
+	// Since foo was canceled, it shouldn't try to push records there.
+	// If it did, it would block forever, and we'd get a timeout.
+	go qr.Match(makeSegment("match on foo, but no foo registered", "abc bar def", "again, no match"))
+	select {
+	case bar := <-barc:
+		if want, have := nopulid+" abc bar def", string(bar); want != have {
+			t.Errorf("want %q, have %q", want, have)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout on second Match")
+	}
+
+	// Cancel the bar query, make sure the chan gets closed.
+	barcancel()
+	select {
+	case bar, ok := <-barc:
+		if ok {
+			t.Errorf("got unexpected record on bar chan: %s", bar)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout on barcancel")
+	}
+}
+
+func TestQueryRegistryClose(t *testing.T) {
+	qr := newQueryRegistry()
+	c := qr.Register(context.Background(), recordFilterPlain([]byte("")))
+	qr.Close()
+	select {
+	case _, ok := <-c:
+		if ok {
+			t.Errorf("expected closed channel, got actual record")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestQueryRegistryRaces(t *testing.T) {
+	t.Parallel()
+
+	// We just gonna do a lot of stuff concurrently.
+	// Try and trigger the race detector.
+	qr := newQueryRegistry()
+	n := 100
+
+	// Manufacture a bunch of segments.
+	segments := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		var buf bytes.Buffer
+		for j := 0; j < 50; j++ {
+			fmt.Fprintf(&buf,
+				"%s %s\n",
+				ulid.MustNew(uint64(j), nil).String(),
+				strings.Repeat(strconv.Itoa(j), 10),
+			)
+		}
+		segments[i] = buf.Bytes()
+	}
+
+	// Register a bunch of queries, wait a bit, then cancel them.
+	var (
+		rd uint64
+		wg sync.WaitGroup
+	)
+	for i := 0; i < n; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		records := qr.Register(ctx, recordFilterPlain([]byte("")))
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range records {
+				atomic.AddUint64(&rd, 1)
+			}
+		}()
+		go func() {
+			time.Sleep(time.Second + time.Duration(rand.Intn(100))*time.Millisecond)
+			cancel() // trigger the other goroutine to exit
+		}()
+	}
+
+	// Match the bunch of segments.
+	for i := 0; i < n; i++ {
+		go func(segment []byte) { qr.Match(segment) }(segments[i])
+	}
+
+	// Wait for it all to finish.
+	wg.Wait()
+	if err := qr.Close(); err != nil {
+		t.Error(err)
+	}
+	t.Logf("%d chan reads", atomic.LoadUint64(&rd))
+}

--- a/pkg/store/query_registry_test.go
+++ b/pkg/store/query_registry_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestQueryRegistry(t *testing.T) {
+	t.Parallel()
+
 	// Set up an empty query registry.
 	qr := newQueryRegistry()
 	defer qr.Close()
@@ -86,6 +88,8 @@ func TestQueryRegistry(t *testing.T) {
 }
 
 func TestQueryRegistryClose(t *testing.T) {
+	t.Parallel()
+
 	qr := newQueryRegistry()
 	c := qr.Register(context.Background(), recordFilterPlain([]byte("")))
 	qr.Close()

--- a/pkg/store/query_test.go
+++ b/pkg/store/query_test.go
@@ -279,7 +279,7 @@ func TestConcurrentFilteringReadCloser(t *testing.T) {
 		t.Run(testcase.name, func(t *testing.T) {
 			in := bytes.NewReader(input.Bytes())
 			re := regexp.MustCompile(testcase.q)
-			pass := recordFilterRegex(testcase.from, testcase.to, re)
+			pass := recordFilterBoundedRegex(testcase.from, testcase.to, re)
 			rc := newConcurrentFilteringReadCloser(ioutil.NopCloser(in), pass, 1024)
 			if want, have := testcase.want, records(rc); !reflect.DeepEqual(want, have) {
 				t.Errorf("want %v, have %v", want, have)

--- a/pkg/store/query_test.go
+++ b/pkg/store/query_test.go
@@ -292,8 +292,8 @@ func TestIssue23(t *testing.T) {
 	var (
 		readerBufSize   = 4096 // bufio.go defaultBufSz
 		bigRecordLength = readerBufSize * 2
-		bigRecord       = bytes.Repeat([]byte{'A'}, bigRecordLength)
-		input           = fmt.Sprintf("%s\n%s\n%s\n", "Alpha", bigRecord, "Beta")
+		bigRecord       = fmt.Sprintf("%s %s", "01B7FTVBVH4CVXC39RBF486QKN", bytes.Repeat([]byte{'A'}, bigRecordLength))
+		input           = fmt.Sprintf("%s\n%s\n%s\n", "01B7FTVBVHZK5GCKXK65JSY4CA Alpha", bigRecord, "01B7FTVBVHYDQC5JDEKC76J0QT Beta")
 		src             = ioutil.NopCloser(strings.NewReader(input))
 		pass            = func([]byte) bool { return true }
 		pipeBufSz       = 1024 * 1024 // different than bufio.Reader bufsz

--- a/pkg/stream/combined_test.go
+++ b/pkg/stream/combined_test.go
@@ -1,0 +1,96 @@
+package stream
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid"
+)
+
+func TestCombined(t *testing.T) {
+	// This test combines Stream and Deduplicate, like in the API.
+	t.Parallel()
+
+	// Our three nodes.
+	type pipe struct {
+		io.Reader
+		io.Writer
+	}
+	var (
+		addrs = []string{"foo", "bar", "baz"}
+		nodes = map[string]pipe{}
+	)
+	for _, addr := range addrs {
+		r, w := io.Pipe()
+		nodes[addr] = pipe{r, w}
+	}
+
+	// Factories for our nodes.
+	peerFactory := func() []string {
+		return addrs
+	}
+	readCloserFactory := func(_ context.Context, addr string) (io.ReadCloser, error) {
+		return ioutil.NopCloser(nodes[addr]), nil
+	}
+
+	// Our stream and deduplicate workers.
+	var (
+		ctx, cancel = context.WithCancel(context.Background())
+		window      = 500 * time.Millisecond
+	)
+	raw := Execute(
+		ctx,
+		peerFactory,
+		readCloserFactory,
+		time.Sleep,
+		time.NewTicker,
+	)
+	deduplicated := Deduplicate(
+		raw,
+		window,
+		time.NewTicker,
+	)
+
+	// We gonna send some unique records.
+	count := 255
+
+	// But we gonna duplicate and send them out of order.
+	go func() {
+		writers := make([]io.Writer, 0, len(nodes))
+		for _, p := range nodes {
+			writers = append(writers, p.Writer)
+		}
+		for i, value := range rand.Perm(count) {
+			id := ulid.MustNew(uint64(value), nil)
+			fmt.Fprintf(writers[(i+0)%len(writers)], "%s %d\n", id, value)
+			fmt.Fprintf(writers[(i+1)%len(writers)], "%s %d\n", id, value)
+		}
+	}()
+
+	// Verify we got what we want.
+	for i := 0; i < count; i++ {
+		id := ulid.MustNew(uint64(i), nil)
+		want := []byte(fmt.Sprintf("%s %d", id, i))
+		have := <-deduplicated
+		if bytes.Compare(want, have) != 0 {
+			t.Fatalf("verifying: want %q, have %q", want, have)
+		}
+	}
+
+	// All done. Make sure we shut down cleanly.
+	cancel()
+	select {
+	case record, ok := <-deduplicated:
+		if ok {
+			t.Errorf("got unexpected record after context cancelation: %q", record)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for shutdown after context cancelation")
+	}
+}

--- a/pkg/stream/deduplicate.go
+++ b/pkg/stream/deduplicate.go
@@ -12,7 +12,7 @@ import (
 // Deduplicate and order records within the given time window.
 // A smaller window may cause duplicate or out-of-order messages.
 // A larger window will cause higher end-to-end latency.
-// The ticker is used to flush the buffer every window / 10.
+// The ticker is used every window / 10 to flush the buffer.
 // The returned chan is closed when the in chan is closed.
 func Deduplicate(in <-chan []byte, window time.Duration, ticker func(time.Duration) *time.Ticker) <-chan []byte {
 	out := make(chan []byte, 1024) // TODO(pb): validate buffer size

--- a/pkg/stream/deduplicate.go
+++ b/pkg/stream/deduplicate.go
@@ -1,0 +1,76 @@
+package stream
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/google/btree"
+	"github.com/oklog/ulid"
+)
+
+// Deduplicate and order records within the given time window.
+// A smaller window may cause duplicate or out-of-order messages.
+// A larger window will cause higher end-to-end latency.
+// The ticker is used to flush the buffer every window / 10.
+// The returned chan is closed when the in chan is closed.
+func Deduplicate(in <-chan []byte, window time.Duration, ticker func(time.Duration) *time.Ticker) <-chan []byte {
+	out := make(chan []byte, 1024) // TODO(pb): validate buffer size
+	go func() {
+		var (
+			d  = dedupe{BTree: btree.New(2)}
+			tk = ticker(window / 10)
+		)
+		defer tk.Stop()
+		defer close(out)
+		for {
+			select {
+			case record, ok := <-in:
+				if !ok {
+					return
+				}
+				d.insert(record)
+
+			case now := <-tk.C:
+				d.remove(now.Add(-window), out)
+			}
+		}
+	}()
+	return out
+}
+
+type dedupe struct{ *btree.BTree }
+
+func (d dedupe) insert(record []byte) {
+	d.BTree.ReplaceOrInsert(item(record))
+}
+
+func (d dedupe) remove(olderThan time.Time, dst chan<- []byte) {
+	var (
+		pivot, _ = ulid.MustNew(ulid.Timestamp(olderThan), nil).MarshalText()
+		toEmit   [][]byte
+	)
+	d.BTree.AscendLessThan(item(pivot), func(i btree.Item) bool {
+		// Unfortunately, can't mutate the tree during iteration.
+		toEmit = append(toEmit, i.(item))
+		return true
+	})
+	for _, record := range toEmit {
+		dst <- record
+		d.BTree.Delete(item(record))
+	}
+}
+
+type item []byte
+
+func (i item) Less(other btree.Item) bool {
+	otherItem := other.(item)
+	if len(i) < ulid.EncodedSize || len(otherItem) < ulid.EncodedSize {
+		panic(fmt.Sprintf("invalid record given to deduplicator: %q v %q", string(i), string(otherItem)))
+	}
+
+	// We rely on the BTree itself to deduplicate. From the docs:
+	// "If !a.Less(b) && !b.Less(a), we treat this to mean a == b."
+	// So make sure to return false when bytes.Compare == 0.
+	return bytes.Compare(i[:ulid.EncodedSize], otherItem[:ulid.EncodedSize]) < 0
+}

--- a/pkg/stream/deduplicate_test.go
+++ b/pkg/stream/deduplicate_test.go
@@ -24,10 +24,10 @@ func TestDeduplicate(t *testing.T) {
 	)
 
 	var (
-		rec1  = []byte(fmt.Sprintf("%s First", ulid.MustNew(ulid.Timestamp(t0), nil).String()))
-		rec2  = []byte(fmt.Sprintf("%s Second alpha", ulid.MustNew(ulid.Timestamp(t1), nil).String()))
-		rec2b = []byte(fmt.Sprintf("%s Second beta", ulid.MustNew(ulid.Timestamp(t1), nil).String()))
-		rec3  = []byte(fmt.Sprintf("%s Third", ulid.MustNew(ulid.Timestamp(t2), nil).String()))
+		rec1  = []byte(fmt.Sprintf("%s Aaaa", ulid.MustNew(ulid.Timestamp(t0), nil).String()))
+		rec2  = []byte(fmt.Sprintf("%s Bbb1", ulid.MustNew(ulid.Timestamp(t1), nil).String()))
+		rec2b = []byte(fmt.Sprintf("%s Bbb2", ulid.MustNew(ulid.Timestamp(t1), nil).String()))
+		rec3  = []byte(fmt.Sprintf("%s Cccc", ulid.MustNew(ulid.Timestamp(t2), nil).String()))
 	)
 
 	// Out-of-order and duplicate inserts.

--- a/pkg/stream/deduplicate_test.go
+++ b/pkg/stream/deduplicate_test.go
@@ -1,0 +1,111 @@
+package stream
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid"
+)
+
+func TestDeduplicate(t *testing.T) {
+	t.Parallel()
+
+	var (
+		in     = make(chan []byte)
+		tick   = make(chan time.Time)
+		ticker = func(time.Duration) *time.Ticker { return &time.Ticker{C: tick} }
+		window = time.Second
+		out    = Deduplicate(in, window, ticker)
+		t0     = time.Now()
+		t1     = t0.Add(1 * window)
+		t2     = t0.Add(2 * window)
+	)
+
+	var (
+		rec1  = []byte(fmt.Sprintf("%s First", ulid.MustNew(ulid.Timestamp(t0), nil).String()))
+		rec2  = []byte(fmt.Sprintf("%s Second alpha", ulid.MustNew(ulid.Timestamp(t1), nil).String()))
+		rec2b = []byte(fmt.Sprintf("%s Second beta", ulid.MustNew(ulid.Timestamp(t1), nil).String()))
+		rec3  = []byte(fmt.Sprintf("%s Third", ulid.MustNew(ulid.Timestamp(t2), nil).String()))
+	)
+
+	// Out-of-order and duplicate inserts.
+	in <- rec3
+	in <- rec1
+	in <- rec3
+	in <- rec2
+	in <- rec2b // ReplaceOrInsert overwrites
+	in <- rec1
+
+	// We haven't ticked the ticker yet, so no records can emerge.
+	select {
+	case record := <-out:
+		t.Fatalf("unexpected record: %q", record)
+	default:
+		// good
+	}
+
+	// Tick up just past one window. We should get the first record.
+	tick <- t0.Add(time.Duration(1.5 * float64(window)))
+
+	// Check the first.
+	select {
+	case record := <-out:
+		if want, have := rec1, record; bytes.Compare(want, have) != 0 {
+			t.Errorf("first record: want %q, have %q", want, have)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for first record")
+	}
+
+	// We shouldn't get any other record yet.
+	select {
+	case record := <-out:
+		t.Fatalf("unexpected record: %q", record)
+	default:
+		// good
+	}
+
+	// Tick way past everything. We should get precisely two more records.
+	tick <- t2.Add(10 * window)
+
+	// Check the second.
+	select {
+	case record := <-out:
+		if want, have := rec2b, record; bytes.Compare(want, have) != 0 {
+			t.Errorf("second record: want %q, have %q", want, have)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for second record")
+	}
+
+	// Check the third.
+	select {
+	case record := <-out:
+		if want, have := rec3, record; bytes.Compare(want, have) != 0 {
+			t.Errorf("third record: want %q, have %q", want, have)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for third record")
+	}
+
+	// No more records.
+	select {
+	case record := <-out:
+		t.Fatalf("unexpected record: %q", record)
+	default:
+		// good
+	}
+
+	// Close the in chan, wait for the close on the out chan.
+	close(in)
+	select {
+	case record, ok := <-out:
+		if ok {
+			t.Fatalf("unexpected record: %q", record)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for chan close")
+	}
+}

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -129,7 +129,7 @@ func readOnce(ctx context.Context, rf ReaderFactory, addr string, sink chan<- []
 	s := bufio.NewScanner(r)
 	for s.Scan() {
 		select {
-		case sink <- append(s.Bytes(), '\n'):
+		case sink <- s.Bytes():
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -139,10 +139,10 @@ func readOnce(ctx context.Context, rcf ReadCloserFactory, addr string, sink chan
 	return s.Err()
 }
 
-// HTTPReaderFactory returns a ReaderFactory that converts the addr to a URL via
-// the addr2url function, makes a GET request via the client, and returns the
-// response body as the ReadCloser.
-func HTTPReaderFactory(client *http.Client, addr2url func(string) string) ReadCloserFactory {
+// HTTPReadCloserFactory returns a ReadCloserFactory that converts the addr to a
+// URL via the addr2url function, makes a GET request via the client, and
+// returns the response body as the ReadCloser.
+func HTTPReadCloserFactory(client *http.Client, addr2url func(string) string) ReadCloserFactory {
 	return func(ctx context.Context, addr string) (io.ReadCloser, error) {
 		req, err := http.NewRequest("GET", addr2url(addr), nil)
 		if err != nil {

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -11,7 +11,7 @@ import (
 )
 
 // PeerFactory should return the current set of peer addresses.
-// Each address will be converted to an io.Reader via the ReaderFactory.
+// Each address will be converted to an io.Reader via the ReadCloserFactory.
 // The PeerFactory is periodically invoked to get the latest set of peers.
 type PeerFactory func() []string
 

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -130,7 +130,8 @@ func readOnce(ctx context.Context, rcf ReadCloserFactory, addr string, sink chan
 	s := bufio.NewScanner(rc)
 	for s.Scan() {
 		select {
-		case sink <- s.Bytes():
+		case sink <- []byte(s.Text()):
+			// We use s.Text to copy the record out of the Scanner.
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/pkg/stream/stream_test.go
+++ b/pkg/stream/stream_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestReadOnce(t *testing.T) {
+	t.Parallel()
+
 	n := 3
 	rf := func(ctx context.Context, addr string) (io.Reader, error) {
 		return &ctxReader{ctx, []byte(addr), int32(10 * n)}, nil
@@ -43,6 +45,8 @@ func TestReadOnce(t *testing.T) {
 }
 
 func TestReadUntilCanceled(t *testing.T) {
+	t.Parallel()
+
 	rf := func(ctx context.Context, addr string) (io.Reader, error) {
 		return &ctxReader{ctx, []byte(addr), 1}, nil
 	}


### PR DESCRIPTION
This PR adds streaming queries. But how do it work?? 🤔 

## The flow of data

Stores regularly poll ingesters for their oldest segment. Stores aggregate ingester segments in memory until they reach an age or size threshold. Then, they replicate those aggregate segments to other store nodes. Only replicated segments are available for query. Once replication is successful, the original ingester segments are confirmed and deleted. See [Design · Consume segments](https://github.com/oklog/oklog/blob/master/DESIGN.md#consume-segments).

This PR adds a few things to the replication handler. First, it [tees the replicated segment to disk and into memory](https://github.com/oklog/oklog/blob/ee6a709160a5c05e6fe61c42ba05dfd4e8a24f0d/pkg/store/api.go#L387-L388), and then [throws the in-memory segment over to a matching function](https://github.com/oklog/oklog/blob/ee6a709160a5c05e6fe61c42ba05dfd4e8a24f0d/pkg/store/api.go#L402). The matching function [sends matching records to registered queries](https://github.com/oklog/oklog/blob/ee6a709160a5c05e6fe61c42ba05dfd4e8a24f0d/pkg/store/query_registry.go#L127-L128) via a channel.

How do queries get registered?

## Stream query lifecycle

Users register a stream query by making a [GET to /store/stream](https://github.com/oklog/oklog/blob/ee6a709160a5c05e6fe61c42ba05dfd4e8a24f0d/pkg/store/api.go#L283). This builds a stream.Execute and stream.Deduplicate pipeline, and feeds the results back to the client via a long-lived HTTP connection (HTTP/1.1 with Transfer-Encoding: Chunked).

[stream.Execute](https://github.com/oklog/oklog/blob/ee6a709160a5c05e6fe61c42ba05dfd4e8a24f0d/pkg/stream/stream.go#L23-L30) is responsible for making connections to each store node's _internal_ stream endpoint. When the topology of the cluster changes, [stream.Execute will detect it](https://github.com/oklog/oklog/blob/ee6a709160a5c05e6fe61c42ba05dfd4e8a24f0d/pkg/stream/stream.go#L55-L56), and either create new connections or terminate old ones. If there is a network interruption between the initial store node and any other store node, stream.Execute will detect the error and [retry until success](https://github.com/oklog/oklog/blob/ee6a709160a5c05e6fe61c42ba05dfd4e8a24f0d/pkg/stream/stream.go#L109-L112).

Recall that each log record will be duplicated on replication_factor store nodes. [stream.Deduplicate](https://github.com/oklog/oklog/blob/ee6a709160a5c05e6fe61c42ba05dfd4e8a24f0d/pkg/stream/deduplicate.go#L12-L16) does a best-effort deduplication of log records [based on their ULID](https://github.com/oklog/oklog/blob/ee6a709160a5c05e6fe61c42ba05dfd4e8a24f0d/pkg/stream/deduplicate.go#L75) over a given time window. Note this produces memory pressure commensurate with throughput; see caveats and risks, below.

The [context from the user request](https://github.com/oklog/oklog/blob/ee6a709160a5c05e6fe61c42ba05dfd4e8a24f0d/pkg/store/api.go#L329) is used to control the lifecycle of all components.

## Internal stream endpoint

We've described how a user stream query fans out to N internal stream queries. The internal stream endpoint is the one that actually [registers the stream query in the query registry](https://github.com/oklog/oklog/blob/ee6a709160a5c05e6fe61c42ba05dfd4e8a24f0d/pkg/store/api.go#L370) and writes the matching records back to the originating node.

## Caveats and risks

The following caveats and risks apply, and should be addressed in future work.

- Record matching does not have robust protection against slow clients.
- Deduplication is not memory-limited. OOM is possible, especially with broad match expressions.
- There are no limits on the number of active streaming queries, that's probably bad.
- It's not been exhaustively profiled. Should we perhaps batch records?
- The transport should be abstracted; see #17.