### PR TITLE
pkg/store: fix makeConcurrentFilteringReadClosers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-  - 1.8rc3
+  - 1.8
   - tip
 install:
   - go get github.com/golang/dep/cmd/dep

--- a/pkg/store/query.go
+++ b/pkg/store/query.go
@@ -323,13 +323,12 @@ func makeConcurrentFilteringReadClosers(fs fs.Filesystem, segments []string, pas
 		}
 	}()
 
-	rcs = make([]io.ReadCloser, len(segments))
-	for i := range segments {
-		f, err := fs.Open(segments[i])
+	for _, segment := range segments {
+		f, err := fs.Open(segment)
 		if err != nil {
 			return rcs, sz, err
 		}
-		rcs[i] = newConcurrentFilteringReadCloser(f, pass, bufsz)
+		rcs = append(rcs, newConcurrentFilteringReadCloser(f, pass, bufsz))
 		sz += f.Size()
 	}
 


### PR DESCRIPTION
If the constructor has a problem opening a segment, previously, the deferred cleanup function would attempt to close a nil io.ReadCloser. This panics and is probably bad. Fixes #41. Thanks, @wangkechun!