### PR TITLE
pkg/{ingest,store}: FileLog can recover better

### DIFF
--- a/pkg/fs/lock_test.go
+++ b/pkg/fs/lock_test.go
@@ -3,23 +3,22 @@ package fs
 import "testing"
 
 func TestLock(t *testing.T) {
-	for _, testcase := range []struct {
-		name    string
-		filesys Filesystem
-	}{
-		{"virtual", NewVirtualFilesystem()},
-		{"real", NewRealFilesystem(false)},
+	t.Parallel()
+
+	lock := "TESTLOCK"
+	for name, filesys := range map[string]Filesystem{
+		"virtual": NewVirtualFilesystem(),
+		"real":    NewRealFilesystem(false),
 	} {
-		lock := "TESTLOCK"
-		t.Run(testcase.name, func(t *testing.T) {
-			r, existed, err := testcase.filesys.Lock(lock)
+		t.Run(name, func(t *testing.T) {
+			r, existed, err := filesys.Lock(lock)
 			if err != nil {
 				t.Fatalf("initial claim: %v", err)
 			}
 			if existed {
 				t.Fatal("initial claim: lock file already exists")
 			}
-			if _, existed, _ = testcase.filesys.Lock(lock); !existed {
+			if _, existed, _ = filesys.Lock(lock); !existed {
 				t.Fatal("second claim: want existed true, have false")
 			}
 			if err := r.Release(); err != nil {
@@ -29,9 +28,9 @@ func TestLock(t *testing.T) {
 				t.Fatal("second release: want error, have none")
 			}
 		})
-		if testcase.filesys.Exists(lock) {
-			t.Errorf("%s: %s still exists", testcase.name, lock)
+		if filesys.Exists(lock) {
+			t.Errorf("%s: %s still exists", name, lock)
 		}
-		testcase.filesys.Remove(lock)
+		filesys.Remove(lock)
 	}
 }

--- a/pkg/ingest/file_log_test.go
+++ b/pkg/ingest/file_log_test.go
@@ -2,6 +2,7 @@ package ingest
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/oklog/oklog/pkg/fs"
@@ -34,7 +35,7 @@ func TestRecoverSegments(t *testing.T) {
 
 	files := map[string]bool{
 		// file                  expected
-		"LOCK":                  true,
+		lockFile:                true,
 		"ACTIVE." + extFlushed:  true,
 		"PENDING." + extFlushed: true,
 		"FLUSHED." + extFlushed: true,
@@ -55,5 +56,45 @@ func TestRecoverSegments(t *testing.T) {
 		} else {
 			t.Errorf("found unexpected file %s", file)
 		}
+	}
+}
+
+func TestLockBehavior(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join("testdata", "TestStaleLockSucceeds")
+	for name, factory := range map[string]func() fs.Filesystem{
+		"virtual": fs.NewVirtualFilesystem,
+		"real":    func() fs.Filesystem { return fs.NewRealFilesystem(false) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			// Generate a filesystem and rootpath.
+			filesys := factory()
+			if err := filesys.MkdirAll(root); err != nil {
+				t.Fatalf("MkdirAll(%s): %v", root, err)
+			}
+			defer filesys.Remove(root)
+
+			// Create a (stale) lock file.
+			f, err := filesys.Create(filepath.Join(root, lockFile))
+			if err != nil {
+				t.Fatalf("Create(%s): %v", lockFile, err)
+			}
+			f.Close()
+
+			// NewFileLog should manage this fine.
+			filelog, err := NewFileLog(filesys, root)
+			if err != nil {
+				t.Fatalf("initial NewFileLog: %v", err)
+			}
+
+			// But a second FileLog should fail.
+			if _, err := NewFileLog(filesys, root); err == nil {
+				t.Fatalf("second NewFileLog: want error, have none")
+			} else {
+				t.Logf("second NewFileLog: got expected error: %v", err)
+			}
+			filelog.Close()
+		})
 	}
 }

--- a/pkg/store/file_log.go
+++ b/pkg/store/file_log.go
@@ -48,7 +48,7 @@ type fileLog struct {
 // Note that we don't own segment files! They may disappear.
 func NewFileLog(filesys fs.Filesystem, root string, segmentTargetSize, segmentBufferSize int64) (Log, error) {
 	if err := filesys.MkdirAll(root); err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "creating path %s", root)
 	}
 	lock := filepath.Join(root, lockFile)
 	r, existed, err := filesys.Lock(lock)
@@ -56,7 +56,9 @@ func NewFileLog(filesys fs.Filesystem, root string, segmentTargetSize, segmentBu
 		return nil, errors.Wrapf(err, "locking %s", lock)
 	}
 	if existed {
-		return nil, errors.Errorf("%s already exists; another process is running, or the file is stale", lock)
+		// The previous owner crashed, but we still got the lock.
+		// So this is like Prometheus "crash recovery" mode.
+		// But we don't have anything special we need to do.
 	}
 	if err := recoverSegments(filesys, root); err != nil {
 		return nil, errors.Wrap(err, "during recovery")


### PR DESCRIPTION
Previously I was misusing the LOCK file mechanism, specifically I was being too conservative. If the constructor gives existed=true err=nil, that's totally fine -- it's akin to Prometheus' crash recovery mode. OK Log doesn't have anything to recover, so we can just proceed.
