### PR TITLE
cmd/oklog: Fix UI mounting in store cmd

### DIFF
--- a/cmd/oklog/store.go
+++ b/cmd/oklog/store.go
@@ -306,7 +306,7 @@ func runStore(args []string) error {
 				}
 			}()
 			mux.Handle("/store/", http.StripPrefix("/store", api))
-			mux.Handle("/ui/", http.StripPrefix("/ui", ui.NewAPI(logger, *uiLocal)))
+			mux.Handle("/ui/", ui.NewAPI(logger, *uiLocal))
 			registerMetrics(mux)
 			registerProfile(mux)
 			return http.Serve(apiListener, mux)


### PR DESCRIPTION
A leftover StripPrefix prevented the proper delivery of static assets for the store command. This is now symmetrical with ingeststore.