### PR TITLE
ui: fetch data with relative paths

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -3,13 +3,13 @@
   <head profile="http://www.w3.org/2005/10/profile">
     <meta charset="utf-8">
     <title>OK Log</title>
-    <link rel="icon" type="image/png" href="/ui/favicon.png">
+    <link rel="icon" type="image/png" href="ui/favicon.png">
     <link href="https://fonts.googleapis.com/css?family=Droid+Sans+Mono|Droid+Sans:400,700" rel="stylesheet">
-    <link href="/ui/styles/normalize.css" rel="stylesheet">
-    <link href="/ui/styles/store.css" rel="stylesheet">
-    <script src="/ui/scripts/oklog.js" type="text/javascript"></script>
+    <link href="ui/styles/normalize.css" rel="stylesheet">
+    <link href="ui/styles/store.css" rel="stylesheet">
+    <script src="ui/scripts/oklog.js" type="text/javascript"></script>
   </head>
   <body>
-    <script src="/ui/scripts/ports.js" type="text/javascript"></script>
+    <script src="ui/scripts/ports.js" type="text/javascript"></script>
  </body>
 </html>

--- a/ui/src/Main.elm
+++ b/ui/src/Main.elm
@@ -250,7 +250,7 @@ queryUrl now query =
             Http.encodeUri (RFC3339.encode (fromTime now))
 
         parts =
-            [ "/store/query?from="
+            [ "../store/query?from="
             , from
             , "&to="
             , to
@@ -268,7 +268,7 @@ streamUrl : Query -> String
 streamUrl query =
     let
         parts =
-            [ "/store/stream?"
+            [ "../store/stream?"
             , "&q="
             , query.term
             ]

--- a/ui/src/Main.elm
+++ b/ui/src/Main.elm
@@ -250,7 +250,7 @@ queryUrl now query =
             Http.encodeUri (RFC3339.encode (fromTime now))
 
         parts =
-            [ "../store/query?from="
+            [ "store/query?from="
             , from
             , "&to="
             , to
@@ -268,7 +268,7 @@ streamUrl : Query -> String
 streamUrl query =
     let
         parts =
-            [ "../store/stream?"
+            [ "store/stream?"
             , "&q="
             , query.term
             ]


### PR DESCRIPTION
This change makes the UI code fetch from '../store'
rather than '/store'.

This will allow the UI to be used even when oklog
is being accessed behind an HTTP proxy that rewrites
the path to be a subdirectory.