### PR TITLE
Improve logs related to calculated cluster advertise addresses

### DIFF
--- a/cmd/oklog/ingest.go
+++ b/cmd/oklog/ingest.go
@@ -201,6 +201,8 @@ func runIngest(args []string) error {
 		level.Warn(logger).Log("err", "this node advertises itself on an unroutable address", "addr", addr.String())
 		level.Warn(logger).Log("err", "this node will be unreachable in the cluster")
 		level.Warn(logger).Log("err", "provide -cluster.advertise-addr as a routable IP address or hostname")
+	} else {
+		level.Debug(logger).Log("calculated_advertise_addr", addr, "note", "this is our best guess")
 	}
 
 	// Bind listeners.

--- a/cmd/oklog/ingeststore.go
+++ b/cmd/oklog/ingeststore.go
@@ -249,6 +249,8 @@ func runIngestStore(args []string) error {
 		level.Warn(logger).Log("err", "this node advertises itself on an unroutable address", "addr", addr.String())
 		level.Warn(logger).Log("err", "this node will be unreachable in the cluster")
 		level.Warn(logger).Log("err", "provide -cluster.advertise-addr as a routable IP address or hostname")
+	} else {
+		level.Debug(logger).Log("calculated_advertise_addr", addr, "note", "this is our best guess")
 	}
 
 	// Bind listeners.

--- a/cmd/oklog/store.go
+++ b/cmd/oklog/store.go
@@ -172,6 +172,8 @@ func runStore(args []string) error {
 		level.Warn(logger).Log("err", "this node advertises itself on an unroutable address", "addr", addr.String())
 		level.Warn(logger).Log("err", "this node will be unreachable in the cluster")
 		level.Warn(logger).Log("err", "provide -cluster.advertise-addr as a routable IP address or hostname")
+	} else {
+		level.Debug(logger).Log("calculated_advertise_addr", addr, "note", "this is our best guess")
 	}
 
 	// Bind listeners.

--- a/pkg/cluster/advertise.go
+++ b/pkg/cluster/advertise.go
@@ -10,21 +10,39 @@ import (
 // CalculateAdvertiseAddress attempts to clone logic from deep within memberlist
 // (NetTransport.FinalAdvertiseAddr) in order to surface its conclusions to the
 // application, so we can provide more actionable error messages if the user has
-// inadvertantly misconfigured their cluster.
+// inadvertantly misconfigured their cluster. Note that the output from this
+// function is only ever logged, it's not used as part of program execution.
+//
+// We do a bit more work here than memberlist; namely, if the addrs are given as
+// hostnames, we try to resolve them to IPs. This is so we don't log potentially
+// confusing messages, like "couldn't parse IP" when a hostname is given and
+// would actually work just fine.
 //
 // https://github.com/hashicorp/memberlist/blob/022f081/net_transport.go#L126
 func CalculateAdvertiseAddress(bindAddr, advertiseAddr string) (net.IP, error) {
 	if advertiseAddr != "" {
+		// First try to parse as IP.
 		ip := net.ParseIP(advertiseAddr)
-		if ip == nil {
-			return nil, errors.Errorf("failed to parse advertise addr '%s'", advertiseAddr)
+		if ip != nil {
+			if ip4 := ip.To4(); ip4 != nil {
+				ip = ip4
+			}
+			return ip, nil
 		}
-		if ip4 := ip.To4(); ip4 != nil {
-			ip = ip4
+
+		// If that fails, try to resolve as hostname.
+		resolved, err := net.ResolveIPAddr("ip", advertiseAddr)
+		if err == nil {
+			if ip4 := resolved.IP.To4(); ip4 != nil {
+				resolved.IP = ip4
+			}
+			return resolved.IP, nil
 		}
-		return ip, nil
+
+		return nil, errors.Errorf("failed to parse advertise addr '%s'", advertiseAddr)
 	}
 
+	// No explicit advertise address, try to deduce one from bind address.
 	if bindAddr == "0.0.0.0" {
 		privateIP, err := sockaddr.GetPrivateIP()
 		if err != nil {
@@ -40,9 +58,20 @@ func CalculateAdvertiseAddress(bindAddr, advertiseAddr string) (net.IP, error) {
 		return ip, nil
 	}
 
+	// Try to parse the addr as an IP.
 	ip := net.ParseIP(bindAddr)
-	if ip == nil {
-		return nil, errors.Errorf("failed to parse bind addr '%s'", bindAddr)
+	if ip != nil {
+		return ip, nil
 	}
-	return ip, nil
+
+	// If that fails, try to resolve as hostname,
+	resolved, err := net.ResolveIPAddr("ip", bindAddr)
+	if err == nil {
+		if ip4 := resolved.IP.To4(); ip4 != nil {
+			resolved.IP = ip4
+		}
+		return resolved.IP, nil
+	}
+
+	return nil, errors.Errorf("failed to parse bind addr '%s'", bindAddr)
 }


### PR DESCRIPTION
Now, if the addrs are given as hostnames, we try to resolve them to IPs before logging any sort of failure. This is so we don't log potentially confusing messages, like "couldn't parse IP" when a hostname is given and would actually work just fine. Addresses #86.
