### PR TITLE
Fix 'during recovery: rename data/store/74.....active 01...-01....flushed:  invalid cross-device link'

### DIFF
--- a/pkg/store/file_log.go
+++ b/pkg/store/file_log.go
@@ -410,7 +410,8 @@ func recoverSegments(filesys fs.Filesystem, root string) error {
 		}
 		var (
 			oldname = path
-			newname = fmt.Sprintf("%s-%s%s", lo, hi, extFlushed)
+			oldpath = filepath.Dir(oldname)
+			newname = filepath.Join(oldpath, fmt.Sprintf("%s-%s%s", lo, hi, extFlushed))
 		)
 		if err := filesys.Rename(oldname, newname); err != nil {
 			return err


### PR DESCRIPTION
This patch fix oklog recovery after unclean shutdown when data stored on Docker volume.