### PR TITLE
ingest: support static and dynamic topics

### DIFF
--- a/pkg/ingest/conn_test.go
+++ b/pkg/ingest/conn_test.go
@@ -10,7 +10,6 @@ import (
 	mathrand "math/rand"
 	"net"
 	"path/filepath"
-	"reflect"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -20,115 +19,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/oklog/oklog/pkg/fs"
+	"github.com/oklog/oklog/pkg/record"
 )
 
-func TestDynamicRecordReader(t *testing.T) {
-	for _, c := range []struct {
-		name  string
-		err   error
-		input string
-		exp   []string
-	}{
-		{
-			name:  "basic",
-			input: "topic_A foo1\ntopic_B foo2\ntopic_A foo2\n",
-			exp:   []string{"topic_A foo1\n", "topic_B foo2\n", "topic_A foo2\n"},
-		}, {
-			name:  "no-final-newline",
-			input: "topic_A foo1\ntopic_B foo2\ntopic_A foo2",
-			exp:   []string{"topic_A foo1\n", "topic_B foo2\n"},
-		}, {
-			name:  "no-topic",
-			input: "topic_A foo1\nabcdef\ntopic_B foo2\n",
-			exp:   []string{"topic_A foo1\n"},
-			err:   ErrIllegalTopicFormat,
-		}, {
-			name:  "empty-record",
-			input: "topic_A foo1\n\ntopic_B foo2\n",
-			exp:   []string{"topic_A foo1\n"},
-			err:   ErrIllegalTopicFormat,
-		}, {
-			name:  "bad-topic",
-			input: "to~pic foo1\n",
-			err:   ErrIllegalTopicFormat,
-		},
-	} {
-		t.Run(c.name, func(t *testing.T) {
-			var res []string
-			var rec []byte
-			var err error
-
-			r := NewDynamicRecordReader(bytes.NewBufferString(c.input))
-			for {
-				rec, err = r()
-				if err != nil {
-					break
-				}
-				res = append(res, string(rec))
-			}
-			if err != io.EOF && err != c.err {
-				t.Fatalf("unexpected error: want %q, got %q", c.err, err)
-			}
-			if !reflect.DeepEqual(c.exp, res) {
-				t.Fatalf("unexpected records: want (%v), got (%v)", c.exp, res)
-			}
-		})
-	}
-}
-func TestStaticRecordReader(t *testing.T) {
-	// Illegal topic characters.
-	if _, err := NewStaticRecordReader("top~ic", nil); err != ErrIllegalTopicFormat {
-		t.Fatalf("expected illegal topic error but got %q", err)
-	}
-
-	for _, c := range []struct {
-		name  string
-		err   error
-		input string
-		exp   []string
-	}{
-		{
-			name:  "basic",
-			input: "foo1\nfoo2\nfoo3\n",
-			exp:   []string{"topic_A foo1\n", "topic_A foo2\n", "topic_A foo3\n"},
-		},
-		{
-			name:  "no-newline",
-			input: "foo1\nfoo2\nfoo3",
-			exp:   []string{"topic_A foo1\n", "topic_A foo2\n"},
-		},
-		{
-			name:  "empty-record",
-			input: "foo1\n\nfoo2\n",
-			exp:   []string{"topic_A foo1\n", "topic_A \n", "topic_A foo2\n"},
-			err:   ErrIllegalTopicFormat,
-		},
-	} {
-		t.Run(c.name, func(t *testing.T) {
-			var res []string
-			var rec []byte
-			var err error
-
-			r, err := NewStaticRecordReader("topic_A", bytes.NewBufferString(c.input))
-			if err != nil {
-				t.Fatalf("unexpected error: %s", err)
-			}
-			for {
-				rec, err = r()
-				if err != nil {
-					break
-				}
-				res = append(res, string(rec))
-			}
-			if err != io.EOF && err != c.err {
-				t.Fatalf("unexpected error: want %q, got %q", c.err, err)
-			}
-			if !reflect.DeepEqual(c.exp, res) {
-				t.Fatalf("unexpected records: want (%v), got (%v)", c.exp, res)
-			}
-		})
-	}
-}
 func TestHandleConnectionsCleanup(t *testing.T) {
 	// Bind a listener on some port.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -160,7 +53,7 @@ func TestHandleConnectionsCleanup(t *testing.T) {
 	)
 	go func() {
 		errc <- HandleConnections(
-			ln, connectionHandler, NewDynamicRecordReader, log, segmentFlushAge, segmentFlushSize,
+			ln, connectionHandler, record.NewDynamicReader, log, segmentFlushAge, segmentFlushSize,
 			connectedClients, bytes, records, syncs, segmentAge, segmentSize,
 		)
 	}()
@@ -217,7 +110,7 @@ func TestHandleConnectionsCleanup(t *testing.T) {
 }
 
 func echo(t *testing.T) ConnectionHandler {
-	return func(read RecordReader, w *Writer, _ IDGenerator, _ prometheus.Gauge) error {
+	return func(read record.Reader, w *Writer, _ IDGenerator, _ prometheus.Gauge) error {
 		for {
 			r, err := read()
 			if err == io.EOF {

--- a/pkg/record/record.go
+++ b/pkg/record/record.go
@@ -1,0 +1,71 @@
+package record
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+)
+
+// ErrIllegalTopicName is returned if a topic's character sequence is invalid.
+var ErrIllegalTopicName = errors.New("illegal topic name")
+
+// Reader emits records.
+// It returns io.EOF if the underlying record source has no more data.
+type Reader func() (record []byte, err error)
+
+// RecordReaderFactory returns a new RecordReader backed by the given reader.
+type ReaderFactory func(io.Reader) Reader
+
+// NewDynamicReader returns a record reader that expects each input record from r
+// to start with a space-delimited topic identifier.
+func NewDynamicReader(r io.Reader) Reader {
+	br := bufio.NewReader(r)
+
+	return func() ([]byte, error) {
+		l, err := br.ReadBytes('\n')
+		if err != nil {
+			return nil, err
+		}
+		// Validate that a correct topic prefix exists.
+		if i := bytes.IndexByte(l, ' '); i < 0 || !IsValidTopic(l[:i]) {
+			return nil, ErrIllegalTopicName
+		}
+		return l, nil
+	}
+}
+
+// StaticReaderFactory returns a RecordReaderFactory that prefixes all records
+// with the given bytes as topic.
+// Callers must ensure the topic identifier is valid.
+func StaticReaderFactory(topic []byte) ReaderFactory {
+	topic = append(topic, ' ')
+
+	return func(r io.Reader) Reader {
+		br := bufio.NewReader(r)
+
+		return func() ([]byte, error) {
+			l, err := br.ReadBytes('\n')
+			if err != nil {
+				return nil, err
+			}
+			return append(topic, l...), nil
+		}
+	}
+}
+
+// IsValidTopic ensures that the a topic only contains allowed characters. It implements
+// the regex [a-zA-Z0-9][a-zA-Z0-9_-]*
+// It takes a byte slice to avoid memory allocations at the caller.
+func IsValidTopic(b []byte) bool {
+	for i, c := range b {
+		if i > 0 && (c == '_' || c == '-') {
+			continue
+		}
+		if ('0' <= c && c <= '9') || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') {
+			continue
+		}
+		return false
+	}
+	return len(b) > 0
+}

--- a/pkg/record/record_test.go
+++ b/pkg/record/record_test.go
@@ -1,0 +1,108 @@
+package record
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"testing"
+)
+
+func TestDynamicReader(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		err   error
+		input string
+		exp   []string
+	}{
+		{
+			name:  "basic",
+			input: "topic_A foo1\ntopic_B foo2\ntopic_A foo2\n",
+			exp:   []string{"topic_A foo1\n", "topic_B foo2\n", "topic_A foo2\n"},
+		}, {
+			name:  "no-final-newline",
+			input: "topic_A foo1\ntopic_B foo2\ntopic_A foo2",
+			exp:   []string{"topic_A foo1\n", "topic_B foo2\n"},
+		}, {
+			name:  "no-topic",
+			input: "topic_A foo1\nabcdef\ntopic_B foo2\n",
+			exp:   []string{"topic_A foo1\n"},
+			err:   ErrIllegalTopicName,
+		}, {
+			name:  "empty-record",
+			input: "topic_A foo1\n\ntopic_B foo2\n",
+			exp:   []string{"topic_A foo1\n"},
+			err:   ErrIllegalTopicName,
+		}, {
+			name:  "bad-topic",
+			input: "to~pic foo1\n",
+			err:   ErrIllegalTopicName,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			var res []string
+			var rec []byte
+			var err error
+
+			r := NewDynamicReader(bytes.NewBufferString(c.input))
+			for {
+				rec, err = r()
+				if err != nil {
+					break
+				}
+				res = append(res, string(rec))
+			}
+			if err != io.EOF && err != c.err {
+				t.Fatalf("unexpected error: want %q, got %q", c.err, err)
+			}
+			if !reflect.DeepEqual(c.exp, res) {
+				t.Fatalf("unexpected records: want (%v), got (%v)", c.exp, res)
+			}
+		})
+	}
+}
+func TestStaticReader(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		err   error
+		input string
+		exp   []string
+	}{
+		{
+			name:  "basic",
+			input: "foo1\nfoo2\nfoo3\n",
+			exp:   []string{"topic_A foo1\n", "topic_A foo2\n", "topic_A foo3\n"},
+		},
+		{
+			name:  "no-newline",
+			input: "foo1\nfoo2\nfoo3",
+			exp:   []string{"topic_A foo1\n", "topic_A foo2\n"},
+		},
+		{
+			name:  "empty-record",
+			input: "foo1\n\nfoo2\n",
+			exp:   []string{"topic_A foo1\n", "topic_A \n", "topic_A foo2\n"},
+			err:   ErrIllegalTopicName,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			var res []string
+			var rec []byte
+			var err error
+
+			r := StaticReaderFactory([]byte("topic_A"))(bytes.NewBufferString(c.input))
+			for {
+				rec, err = r()
+				if err != nil {
+					break
+				}
+				res = append(res, string(rec))
+			}
+			if err != io.EOF && err != c.err {
+				t.Fatalf("unexpected error: want %q, got %q", c.err, err)
+			}
+			if !reflect.DeepEqual(c.exp, res) {
+				t.Fatalf("unexpected records: want (%v), got (%v)", c.exp, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds topic awareness to the ingestion layer. Users can choose
between assigning a static topic to all incoming data or validating
that all incoming records are prefixed with a dynamic topic.

Beyond ensuring that all records are prefixed with a topic, the
ingesters do not treat topics specially.

As suggested on #113 I only added `static` and `dynamic` for now. `connection` lacks capable clients at this point I believe. `none` is equivalent to `static` and leaving the topic name at the default.